### PR TITLE
Refactored plugin registrar, added mir pass (in progress)

### DIFF
--- a/examples/ssahli.rs
+++ b/examples/ssahli.rs
@@ -1,20 +1,30 @@
 #![feature(plugin, custom_attribute)]
 #![plugin(rustproof)]
-
-//extern crate rustproof;
+#![allow(dead_code)]
 
 fn main() {
     let mut x = 3;
     x = add_five(x);
+    x = add_three(x);
     println!("{:?}", x);
 }
 
+// This is acceptable: it is placed over a function
 #[condition(pre="x > 0", post="x >= 5")]
 fn add_five(mut x: i32) -> i32 {
     x = x + 5;
     return x;
 }
 
-//struct Foo {
-//    x: i32,
-//}
+fn add_three(mut x: i32) -> i32 {
+    x = x + 3;
+    return x;
+}
+
+// This should error/warn: it isn't placed over a function
+#[condition(pre="x > 0", post="x >= 5")]
+struct Foo {
+    x: i32,
+}
+
+struct Bar;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,17 +148,25 @@ impl <'tcx> MirPass<'tcx> for MirVisitor {
         let def_id = tcx.map.local_def_id(item_id);
         let name = tcx.item_path_str(def_id);
         let attrs = tcx.map.attrs(item_id);
-        println!("node id: {:#?}", item_id);
-        println!("\tdef id: {:#?}", def_id);
-        println!("\tfn name: {:#?}", name);
-        println!("\tattributes: {:#?}", attrs);
-        //parser::parse_function();
+
+        //println!("node id: {:#?}", item_id);
+        //println!("\tdef id: {:#?}", def_id);
+        //println!("\tfn name: {:#?}", name);
+        //println!("\tattributes: {:#?}", attrs);
+
+        self.builder.func_name = name;
+        println!("\tfn name: {:#?}", self.builder.func_name);
+
+        // FIXME: the parser needs to be redone pretty much :(
+        //parser::parse_function(self); // Maybe not needed?
+        //parser::parse_attribute(self, attrs);
+
         MirVisitor::visit_mir(self, mir);
     }
 }
 
 impl<'tcx> Visitor<'tcx> for MirVisitor {
     fn visit_mir(&mut self, mir: &Mir<'tcx>) {
-
+        parser::parse_mir(&self.builder, mir); // FIXME: needs to be implemented in parser
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,16 +90,18 @@ fn control_flow(meta: &MetaItem, item: &Annotatable) {
 #[plugin_registrar]
 pub fn registrar(reg: &mut Registry) {
     //reg.register_syntax_extension(intern("condition"), MultiDecorator(Box::new(expand_condition)));
-    let builder = MirVisitor {
-        func_name: "".to_string(),
-        func_span: None,
-        func: None,
-        pre_str: "".to_string(),
-        post_str: "".to_string(),
-        pre_span: None,
-        post_span: None,
+    let visitor = MirVisitor {
+        builder : Attr {
+            func_name: "".to_string(),
+            func_span: None,
+            func: None,
+            pre_str: "".to_string(),
+            post_str: "".to_string(),
+            pre_span: None,
+            post_span: None,
+        },
     };
-    reg.register_mir_pass(Box::new(builder));
+    reg.register_mir_pass(Box::new(visitor));
 }
 
 // FIXME: FOR NOW, THIS IS COMMENTED OUT FOR REFERENCE PURPOSES.
@@ -133,14 +135,7 @@ fn expand_bad_item(ctx: &mut ExtCtxt, span: Span) {
 
 
 struct MirVisitor {
-    pub func_name: String,
-    pub func_span: Option<Span>,
-    //pub func_stmts: Vec<_>,
-    pub func: Option<syntax::ptr::P<syntax::ast::Block>>,
-    pub pre_span: Option<Span>,
-    pub post_span: Option<Span>,
-    pub pre_str: String,
-    pub post_str: String,
+    builder: Attr,
 }
 
 // This must be here, and it must be blank
@@ -157,6 +152,7 @@ impl <'tcx> MirPass<'tcx> for MirVisitor {
         println!("\tdef id: {:#?}", def_id);
         println!("\tfn name: {:#?}", name);
         println!("\tattributes: {:#?}", attrs);
+        //parser::parse_function();
         MirVisitor::visit_mir(self, mir);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ fn control_flow(meta: &MetaItem, item: &Annotatable) {
 #[plugin_registrar]
 pub fn registrar(reg: &mut Registry) {
     //reg.register_syntax_extension(intern("condition"), MultiDecorator(Box::new(expand_condition)));
-    reg.register_mir_pass(Box::new(MirVisitor {
+    let builder = MirVisitor {
         func_name: "".to_string(),
         func_span: None,
         func: None,
@@ -98,7 +98,8 @@ pub fn registrar(reg: &mut Registry) {
         post_str: "".to_string(),
         pre_span: None,
         post_span: None,
-    }));
+    };
+    reg.register_mir_pass(Box::new(builder));
 }
 
 // FIXME: FOR NOW, THIS IS COMMENTED OUT FOR REFERENCE PURPOSES.
@@ -156,7 +157,7 @@ impl <'tcx> MirPass<'tcx> for MirVisitor {
         println!("\tdef id: {:#?}", def_id);
         println!("\tfn name: {:#?}", name);
         println!("\tattributes: {:#?}", attrs);
-        MirVisitor.visit_mir(mir);
+        MirVisitor::visit_mir(self, mir);
     }
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -22,6 +22,7 @@ use syntax::parse::token::intern;
 use syntax::ptr::P;
 use super::dev_tools; // FIXME: remove for production
 use super::Attr;
+use rustc::mir::repr::{Mir, BasicBlock, BasicBlockData};
 
 
 /// Parses function information from an *Annotatable* associated with an attribute.
@@ -122,6 +123,12 @@ pub fn parse_attribute(builder: &mut Attr, meta: &MetaItem) {
     //println!("precondition {:?}", builder.clone().pre.unwrap());
     //println!("postcondition {:?}", builder.clone().post.unwrap());
 }
+
+// FIXME: Needs implementing
+pub fn parse_mir(builder: &Attr, mir: &Mir) {
+    //println!("\nfn name: {:#?}", builder.func_name);
+}
+
 
 pub fn demo() {
     println!("parser - reporting in");


### PR DESCRIPTION
Mir pass is in place, control_flow won't be used, parser needs reworking

Re: Mir pass: register_mir_pass is in place, MirVisitor handles all implementations and contains an instance of the Attr struct (accessed within register_mir_pass trait functions using self.builder).

Re: control_flow: since we're now using run_pass and visit_mir, control flow can be handled separately in those two functions. run_pass runs over each individual function (need to add checks to see if pre/post conditions are available, if the attribute is called "condition", if the attribute is registered on "main" or "main::", etc)., and visit_mir visits the actual mir code to be sent to the parser (I've added a parser::parse_mir() for this, needs implementing)

Re: parser rework: since we're no longer handing the parser data from the register_syntax_extension (which has no access to mir and consumes the attribute upon exit), the parser needs to handle the new data types being used within the mir pass (specifically the Spanned<Attribute_>, see lib.rs line 150)