### PR TITLE
Support for tuples

### DIFF
--- a/examples/ssahli.rs
+++ b/examples/ssahli.rs
@@ -13,25 +13,6 @@ fn main() {}
 // This is acceptable: it is placed over a function
 #[condition(pre="x: i32 > 0", post="return: i32 >= 5")]
 fn add_five_or_three(x: i32) -> i32 {
-    if x > 3 {
-        x + 5
-    }
-    else {
-        x + 3
-    }
+    let y = (5, x, 3, 7);
+    y.3
 }
-/*
-fn add_three(mut x: i32) -> i32 {
-    x = x + 3;
-    return x;
-}
-*/
-// This should error/warn: it isn't placed over a function
-/*
-#[condition(pre="x: int > 0", post="x: int >= 5")]
-struct Foo {
-    x: i32,
-}
-
-struct Bar;
-*/

--- a/src/weakest_precondition/mod.rs
+++ b/src/weakest_precondition/mod.rs
@@ -236,7 +236,8 @@ pub fn gen_stmt(mut wp: Expression, stmt: Statement, data: &(Vec<&ArgDecl>, Vec<
     let mut var = gen_lvalue(lvalue.unwrap(), data);
 
     // The expression on the right-hand side of the assignment
-    let expression : Expression = match rvalue.clone().unwrap() {
+    let mut expression = Vec::new();
+    match rvalue.clone().unwrap() {
         Rvalue::CheckedBinaryOp(ref binop, ref loperand, ref roperand) => {
             // FIXME: This probably works for the MIR we encounter, but only time (and testing) will tell
             // Although the checked operators will return a tuple, we will only want to replace the first field of that tuple
@@ -284,11 +285,11 @@ pub fn gen_stmt(mut wp: Expression, stmt: Statement, data: &(Vec<&ArgDecl>, Vec<
             let lvalue: Expression = gen_operand(&loperand, data);
             let rvalue: Expression = gen_operand(&roperand, data);
 
-            Expression::BinaryExpression( BinaryExpressionData {
+            expression.push(Expression::BinaryExpression( BinaryExpressionData {
                 op: op,
                 left: Box::new(lvalue),
                 right: Box::new(rvalue)
-             } )
+            } ));
         },
         Rvalue::BinaryOp(ref binop, ref lval, ref rval) => {
             let op: BinaryOperator = match binop {
@@ -345,11 +346,11 @@ pub fn gen_stmt(mut wp: Expression, stmt: Statement, data: &(Vec<&ArgDecl>, Vec<
             let lvalue: Expression = gen_operand(&lval, data);
             let rvalue: Expression = gen_operand(&rval, data);
 
-            Expression::BinaryExpression( BinaryExpressionData {
+            expression.push(Expression::BinaryExpression( BinaryExpressionData {
                 op: op,
                 left: Box::new(lvalue),
                 right: Box::new(rvalue)
-             } )
+            } ));
         },
         Rvalue::UnaryOp(ref unop, ref val) => {
             let op: UnaryOperator = match unop {
@@ -363,31 +364,44 @@ pub fn gen_stmt(mut wp: Expression, stmt: Statement, data: &(Vec<&ArgDecl>, Vec<
 
             let value: Expression = gen_operand(&val, data);
 
-            Expression::UnaryExpression( UnaryExpressionData {
+            expression.push(Expression::UnaryExpression( UnaryExpressionData {
                 op: op,
                 e: Box::new(value)
-            } )
+            } ));
         },
         Rvalue::Use(ref operand) => {
-            gen_operand(operand, data)
+            expression.push(gen_operand(operand, data));
         },
         Rvalue::Aggregate(ref ag_kind, ref vec_operand) => {
-            // FIXME: need to support tuples in expression to proceed further
-            //println!("DEBUG\n{:?} {:?}\n", ag_kind, vec_operand);
-            //unimplemented!();
-            Expression::VariableMapping(var.clone())
+            match ag_kind {
+                &AggregateKind::Tuple => {
+                    for i in 0..vec_operand.len() {
+                        expression.push(Expression::VariableMapping( VariableMappingData {
+                            name: var.name.as_str().to_string() + "." + i.to_string().as_str(),
+                            var_type: gen_ty(&vec_operand[i], data)
+                        } ));
+                    }
+                },
+                // FIXME: Vectors are weird. let's not bother with them yet
+                /*
+                &AggregateKind::Vec => {
+                    unimplemented!()
+                },
+                */
+                _ => { rp_error!("Unsupported aggregate: only tuples are supported"); }
+            }
         },
         Rvalue::Cast(ref cast_kind, ref cast_operand, ref cast_ty) => {
             // FIXME: doesnt do anything
             //println!("cast {:?} {:?} {:?} ", cast_kind, cast_operand, cast_ty);
             //unimplemented!();
-            Expression::VariableMapping(var.clone())
+            expression.push(Expression::VariableMapping(var.clone()));
         },
         Rvalue::Ref(ref ref_region, ref ref_borrow_kind, ref ref_lvalue) => {
             // FIXME: doesnt do anything
             //println!("ref {:?} {:?} {:?} ", ref_region, ref_borrow_kind, ref_lvalue);
             //unimplemented!();
-            Expression::VariableMapping(var.clone())
+            expression.push(Expression::VariableMapping(var.clone()));
         },
         Rvalue::Box(..) => { unimplemented!(); },
         Rvalue::Len(..) => { unimplemented!(); },
@@ -395,7 +409,9 @@ pub fn gen_stmt(mut wp: Expression, stmt: Statement, data: &(Vec<&ArgDecl>, Vec<
     };
 
     // Replace any appearance of var in the weakest precondition with the expression
-    substitute_variable_with_expression( &mut wp, &var, &expression );
+    for i in 0..expression.len() {
+        substitute_variable_with_expression( &mut wp, &var, &expression[i] );
+    }
     if DEBUG { println!("new expression\t\t{:?}\n---------------------", wp.clone());}
     return Some(wp);
 }


### PR DESCRIPTION
Turns out to be much easier than I thought. Most of my attempts ended up being silly.
* Still no vector support (not part of MVP)
* Expression in gen_stmt is now a vector of expressions, since tuples will generate more than one replacement
* Replacements don't seem to be working correctly on "return" in post-condition