### PR TITLE
Optional debug print, handling unused_attribute warning

### DIFF
--- a/examples/ssahli.rs
+++ b/examples/ssahli.rs
@@ -1,5 +1,5 @@
 #![feature(plugin, custom_attribute)]
-#![plugin(rustproof)]
+#![plugin(rustproof(debug))]
 #![allow(dead_code)]
 /*
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //     - String to expression //libsyntax as parser / parse_exper_from_source_str
 
 #![crate_type="dylib"]
-#![feature(plugin_registrar, rustc_private, stmt_expr_attributes)]
+#![feature(plugin_registrar, rustc_private)]
 
 #[macro_use] pub extern crate syntax;
 #[macro_use] pub mod reporting;

--- a/src/reporting/mod.rs
+++ b/src/reporting/mod.rs
@@ -9,9 +9,10 @@
 // except according to those terms.
 
 // Unused, uncomment if they are needed
-// use errors::{ColorConfig, Handler};
-// use syntax::codemap::CodeMap;
-// use std::rc::Rc;
+use errors::{ColorConfig, Handler};
+use syntax::codemap::CodeMap;
+use std::rc::Rc;
+use std::process;
 
 // Warning macro
 macro_rules! rp_warn {

--- a/src/smt_output/mod.rs
+++ b/src/smt_output/mod.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use super::DEBUG;
-
 use std::fmt::Debug;
 use std::process;
 
@@ -28,7 +26,7 @@ use expression::*;
 
 // Now that we have a verification condition, we need to verify that it is always true.
 // Simply satisfying P->WP isn't enough. We need to verify that !(P->WP) is *unsatisfiable*
-pub fn gen_smtlib (vc: &Expression, name: String) {
+pub fn gen_smtlib (vc: &Expression, name: String, debug: bool) {
     // Define an instance of Z3
     let mut z3: z3::Z3 = Default::default();
 
@@ -42,7 +40,7 @@ pub fn gen_smtlib (vc: &Expression, name: String) {
     let vcon = solver.expr2smtlib(&vc);
     let _ = solver.assert(core::OpCodes::Not, &[vcon]);
 
-    let (res, check) = solver.solve(&mut z3, DEBUG);
+    let (res, check) = solver.solve(&mut z3, debug);
     match res {
         Ok(..) => {
             match check {


### PR DESCRIPTION
To enable/disable debug prints:
In user file, set `#![plugin(rustproof(debug))]` for debug info;
set `#![plugin(rustproof)]` for no debug info